### PR TITLE
update gitignore to ignore whole .idea direc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,11 +34,7 @@ captures/
 
 # Intellij
 *.iml
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/gradle.xml
-.idea/dictionaries
-.idea/libraries
+.idea
 
 # Keystore files
 *.jks


### PR DESCRIPTION
After setting this up in Android Studio two new files were generated, modules.xml and vcs.xml. Two others were modified: misc.xml and runConfigurations.xml. Probably easier to just ignore the whole directory
