### PR TITLE
Disable configuration on demand

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# Not yet supported by the Android Gradle Plugin
+org.gradle.configureondemand=false


### PR DESCRIPTION
Configuration on demand [isn't supported](https://stackoverflow.com/questions/49990933/configuration-on-demand-is-not-supported-by-the-current-version-of-the-android-g) by the latest versions of the Android Gradle Plugin. This PR disables it during the build.

Note that when building in Android Studio, the 'Configure on Demand' setting in 'Build, Execution, Deployment > Compiler' will override this value.